### PR TITLE
Registered commands with some fixes and new method

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.extendedclip.papi.expansion.javascript</groupId>
   <artifactId>javascript-expansion</artifactId>
-  <version>1.4.2</version>
+  <version>1.4.3</version>
   <name>PAPI-Expansion-Javascript</name>
   <description>PlaceholderAPI expansion for javascript placeholders</description>
     

--- a/src/main/java/com/extendedclip/papi/expansion/javascript/JavascriptCommands.java
+++ b/src/main/java/com/extendedclip/papi/expansion/javascript/JavascriptCommands.java
@@ -1,0 +1,70 @@
+package com.extendedclip.papi.expansion.javascript;
+
+import com.google.common.collect.Lists;
+import net.md_5.bungee.api.chat.ClickEvent;
+import net.md_5.bungee.api.chat.ComponentBuilder;
+import net.md_5.bungee.api.chat.HoverEvent;
+import net.md_5.bungee.api.chat.TextComponent;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+
+import static me.clip.placeholderapi.util.Msg.color;
+
+public class JavascriptCommands extends Command {
+
+    private JavascriptExpansion ex;
+
+    public JavascriptCommands(JavascriptExpansion ex) {
+        super("papijsp");
+        this.setDescription("JavaScript expansion commands");
+        this.usageMessage = color("&cIncorrect usage. &7/papijsp help");
+        this.setAliases(Lists.newArrayList("daddyjsp"));
+
+        this.ex = ex;
+    }
+
+    public boolean execute(CommandSender sender, String label, String[] args) {
+
+        if (sender.hasPermission("placeholderapi.admin")) {
+            if (args.length == 0) {
+                sender.sendMessage(color("&eJavascript expansion &fv" + ex.getVersion()));
+                sender.sendMessage(color("&eCreated by: &f" + ex.getAuthor()));
+                return true;
+            }
+
+            if (args.length == 1) {
+                switch (args[0].toLowerCase()) {
+                    case "help":
+                        sender.sendMessage(color("&eJavascript expansion &fv" + ex.getVersion()));
+                        sender.sendMessage("");
+                        sender.sendMessage(color("&e/papijsp reload &7- &fReload your Javascript placeholders only."));
+                        sender.sendMessage(color("&e/papijsp list &7- &fLists loaded Javascript placeholders' identifiers."));
+                        sender.sendMessage("");
+                        sender.sendMessage(color("&eCreated by: &f" + ex.getAuthor()));
+                        TextComponent wiki = new TextComponent(color("&eWiki: "));
+                        TextComponent click = new TextComponent(color("&fClick here"));
+                        click.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new ComponentBuilder(color("&6Check the wiki for more info!")).create()));
+                        click.setClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, "https://github.com/PlaceholderAPI/Javascript-Expansion/wiki"));
+                        wiki.addExtra(click);
+                        sender.spigot().sendMessage(wiki);
+                        return true;
+                    case "reload":
+                        sender.sendMessage(color("&6Reloading..."));
+                        int l = ex.reloadScripts();
+                        sender.sendMessage(color("&f" + l + " &escript" + (l == 1 ? "" : "s")+ " loaded."));
+                        return true;
+                    case "list":
+                        sender.sendMessage(color("&f" + ex.getAmountLoaded() + " &6script" + (ex.getAmountLoaded() == 1 ? "" : "s")+ " loaded."));
+		                sender.sendMessage(color("&e" + String.join("&f, &e", ex.getLoadedIdentifiers())));
+                        return true;
+                }
+            }
+        } else {
+            sender.sendMessage(color("You don't have permission to do that!"));
+            return true;
+        }
+
+        sender.sendMessage(usageMessage);
+        return true;
+    }
+}

--- a/src/main/java/com/extendedclip/papi/expansion/javascript/JavascriptCommands.java
+++ b/src/main/java/com/extendedclip/papi/expansion/javascript/JavascriptCommands.java
@@ -1,3 +1,23 @@
+/*
+ *
+ * Javascript-Expansion
+ * Copyright (C) 2019 Ryan McCarthy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ */
 package com.extendedclip.papi.expansion.javascript;
 
 import com.google.common.collect.Lists;

--- a/src/main/java/com/extendedclip/papi/expansion/javascript/JavascriptExpansion.java
+++ b/src/main/java/com/extendedclip/papi/expansion/javascript/JavascriptExpansion.java
@@ -74,14 +74,7 @@ public class JavascriptExpansion extends PlaceholderExpansion implements Cacheab
 	
 	@Override
 	public boolean register() {
-		if (globalEngine == null) {
-			try {
-				globalEngine = new ScriptEngineManager().getEngineByName(getString("engine", "javascript"));
-			} catch (NullPointerException ex) {
-				getPlaceholderAPI().getLogger().warning("Javascript engine type was invalid! Defaulting to 'javascript'");
-				globalEngine = new ScriptEngineManager().getEngineByName("javascript");
-			}	
-		}
+        this.getGlobalEngine();
 
 		try {
 			final Field commandMap = Bukkit.getServer().getClass().getDeclaredField("commandMap");
@@ -170,6 +163,14 @@ public class JavascriptExpansion extends PlaceholderExpansion implements Cacheab
 	}
 	
 	public ScriptEngine getGlobalEngine() {
+        if (globalEngine == null) {
+            try {
+                globalEngine = new ScriptEngineManager().getEngineByName(getString("engine", "javascript"));
+            } catch (NullPointerException ex) {
+                getPlaceholderAPI().getLogger().warning("Javascript engine type was invalid! Defaulting to 'javascript'");
+                globalEngine = new ScriptEngineManager().getEngineByName("javascript");
+            }
+        }
 		return globalEngine;
 	}
 

--- a/src/main/java/com/extendedclip/papi/expansion/javascript/JavascriptExpansion.java
+++ b/src/main/java/com/extendedclip/papi/expansion/javascript/JavascriptExpansion.java
@@ -113,11 +113,6 @@ public class JavascriptExpansion extends PlaceholderExpansion implements Cacheab
 	public String getIdentifier() {
 		return "javascript";
 	}
-
-	@Override
-	public String getPlugin() {
-		return null;
-	}
 	
 	@Override
 	public String getVersion() {

--- a/src/main/java/com/extendedclip/papi/expansion/javascript/JavascriptExpansion.java
+++ b/src/main/java/com/extendedclip/papi/expansion/javascript/JavascriptExpansion.java
@@ -36,8 +36,8 @@ import me.clip.placeholderapi.expansion.Configurable;
 import me.clip.placeholderapi.expansion.PlaceholderExpansion;
 
 import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.command.CommandMap;
-import org.bukkit.entity.Player;
 
 public class JavascriptExpansion extends PlaceholderExpansion implements Cacheable, Configurable {
 	
@@ -82,7 +82,7 @@ public class JavascriptExpansion extends PlaceholderExpansion implements Cacheab
 			commandMap.setAccessible(true);
 			cmdMap = (CommandMap) commandMap.get(Bukkit.getServer());
 
-			cmdMap.register("papijsp", new JavascriptCommands(this));
+			cmdMap.register("placeholderapi", new JavascriptCommands(this));
 		} catch(Exception e) {
 			e.printStackTrace();
 		}
@@ -105,7 +105,7 @@ public class JavascriptExpansion extends PlaceholderExpansion implements Cacheab
 	}
 
 	@Override
-	public String onPlaceholderRequest(Player p, String identifier) {
+	public String onRequest(OfflinePlayer p, String identifier) {
 		if (p == null) {
 			return "";
 		}

--- a/src/main/java/com/extendedclip/papi/expansion/javascript/JavascriptExpansion.java
+++ b/src/main/java/com/extendedclip/papi/expansion/javascript/JavascriptExpansion.java
@@ -1,7 +1,7 @@
 /*
  *
  * Javascript-Expansion
- * Copyright (C) 2018 Ryan McCarthy
+ * Copyright (C) 2019 Ryan McCarthy
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/com/extendedclip/papi/expansion/javascript/JavascriptExpansion.java
+++ b/src/main/java/com/extendedclip/papi/expansion/javascript/JavascriptExpansion.java
@@ -88,7 +88,8 @@ public class JavascriptExpansion extends PlaceholderExpansion implements Cacheab
 		}
 
 		config = new JavascriptPlaceholdersConfig(this);
-		config.loadPlaceholders();
+        int l = reloadScripts();
+        getPlaceholderAPI().getLogger().info("" + l + " script" + (l == 1 ? "" : "s")+ " loaded.");
 		return super.register();
 	}
 	

--- a/src/main/java/com/extendedclip/papi/expansion/javascript/JavascriptPlaceholder.java
+++ b/src/main/java/com/extendedclip/papi/expansion/javascript/JavascriptPlaceholder.java
@@ -29,6 +29,7 @@ import javax.script.ScriptException;
 
 import org.apache.commons.lang.Validate;
 import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.configuration.InvalidConfigurationException;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
@@ -201,5 +202,9 @@ public class JavascriptPlaceholder {
 			this.data = null;
 		}
 		this.cfg = null;
+	}
+
+	public String setPAPIPlaceholder(OfflinePlayer p, String identifier) {
+		return PlaceholderAPI.setPlaceholders(p, identifier);
 	}
 }

--- a/src/main/java/com/extendedclip/papi/expansion/javascript/JavascriptPlaceholder.java
+++ b/src/main/java/com/extendedclip/papi/expansion/javascript/JavascriptPlaceholder.java
@@ -205,10 +205,10 @@ public class JavascriptPlaceholder {
 	}
 
 	public String setPAPIPlaceholder(OfflinePlayer p, String identifier) {
-		return PlaceholderAPI.setPlaceholders(p, identifier);
+		return PlaceholderAPI.setPlaceholders(p, "%" + identifier + "%");
 	}
 
 	public String setPAPIRelPlaceholder(Player p1, Player p2, String identifier) {
-		return PlaceholderAPI.setRelationalPlaceholders(p1, p2, identifier);
+		return PlaceholderAPI.setRelationalPlaceholders(p1, p2, "%" + identifier + "%");
 	}
 }

--- a/src/main/java/com/extendedclip/papi/expansion/javascript/JavascriptPlaceholder.java
+++ b/src/main/java/com/extendedclip/papi/expansion/javascript/JavascriptPlaceholder.java
@@ -86,7 +86,7 @@ public class JavascriptPlaceholder {
 		return script;
 	}
 	
-	public String evaluate(Player p, String... args) {
+	public String evaluate(OfflinePlayer p, String... args) {
 		String exp = PlaceholderAPI.setPlaceholders(p, script);
 
         try {

--- a/src/main/java/com/extendedclip/papi/expansion/javascript/JavascriptPlaceholder.java
+++ b/src/main/java/com/extendedclip/papi/expansion/javascript/JavascriptPlaceholder.java
@@ -207,4 +207,8 @@ public class JavascriptPlaceholder {
 	public String setPAPIPlaceholder(OfflinePlayer p, String identifier) {
 		return PlaceholderAPI.setPlaceholders(p, identifier);
 	}
+
+	public String setPAPIRelPlaceholder(Player p1, Player p2, String identifier) {
+		return PlaceholderAPI.setRelationalPlaceholders(p1, p2, identifier);
+	}
 }

--- a/src/main/java/com/extendedclip/papi/expansion/javascript/JavascriptPlaceholder.java
+++ b/src/main/java/com/extendedclip/papi/expansion/javascript/JavascriptPlaceholder.java
@@ -1,7 +1,7 @@
 /*
  *
  * Javascript-Expansion
- * Copyright (C) 2018 Ryan McCarthy
+ * Copyright (C) 2019 Ryan McCarthy
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/com/extendedclip/papi/expansion/javascript/JavascriptPlaceholdersConfig.java
+++ b/src/main/java/com/extendedclip/papi/expansion/javascript/JavascriptPlaceholdersConfig.java
@@ -1,7 +1,7 @@
 /*
  *
  * Javascript-Expansion
- * Copyright (C) 2018 Ryan McCarthy
+ * Copyright (C) 2019 Ryan McCarthy
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/com/extendedclip/papi/expansion/javascript/ScriptData.java
+++ b/src/main/java/com/extendedclip/papi/expansion/javascript/ScriptData.java
@@ -1,7 +1,7 @@
 /*
  *
  * Javascript-Expansion
- * Copyright (C) 2018 Ryan McCarthy
+ * Copyright (C) 2019 Ryan McCarthy
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
- Moved papijsp commands to another class and made it registered command instead of using the event (Credits go to Google and Clip for the register part, took it from Google and from clip's custom expansion so thank you both 😄 ). with new format for messages.
- Fixed `Failed to set ScriptEngine for javascript placeholder:` error, when reloading with `/papijsp reload` command.
- Added new method to be able to parse PAPI placeholders in your js script with js args, and the ability to compare the placeholder's value and other stuff.
- Updated the header of classes to 2019!! :p
- bumped the version to 1.4.3.

Tested the expansion on 1.12.2 (guess if it works there it will for other versions) and everything seems fine. The only issue is that when u reload with `/papi reload` the `/papijsp list` command returns 0 scripts loaded and if you reloaded with `/papijsp reload` it works.
but for reloading with `/papi reload` will not return the correct value if you added new placeholders.
tried to fix that with many ways, but no luck. Not sure if what i'm thinking of is the problem but if it is, afaik theres no way to solve it :(

Compiled version if anyone wants to test it: https://aboodyy.net/PAPI-Expansion-Javascript.jar

I didn't change all of [that](https://img.aboodyy.net/19.06.24_19-36.png), idk whats wrong with GitHub