### PR TITLE
ScriptEngineManager

### DIFF
--- a/src/main/java/com/extendedclip/papi/expansion/javascript/ExpansionUtils.java
+++ b/src/main/java/com/extendedclip/papi/expansion/javascript/ExpansionUtils.java
@@ -68,24 +68,26 @@ public class ExpansionUtils {
 
     // Only support for Nashorn engine!
     protected static Object jsonToJava(Object jsObj) {
-        if (jsObj instanceof ScriptObjectMirror) {
-            ScriptObjectMirror jsObjectMirror = (ScriptObjectMirror) jsObj;
-            if (jsObjectMirror.isArray()) {
-                List<Object> list = new ArrayList<>();
-                for (Map.Entry<String, Object> entry : jsObjectMirror.entrySet()) {
-                    list.add(jsonToJava(entry.getValue()));
+        try {
+            if (jsObj instanceof ScriptObjectMirror) {
+                ScriptObjectMirror jsObjectMirror = (ScriptObjectMirror) jsObj;
+                if (jsObjectMirror.isArray()) {
+                    List<Object> list = new ArrayList<>();
+                    for (Map.Entry<String, Object> entry : jsObjectMirror.entrySet()) {
+                        list.add(jsonToJava(entry.getValue()));
+                    }
+                    return list;
+                } else {
+                    Map<String, Object> map = new HashMap<>();
+                    for (Map.Entry<String, Object> entry : jsObjectMirror.entrySet()) {
+                        map.put(entry.getKey(), jsonToJava(entry.getValue()));
+                    }
+                    return map;
                 }
-                return list;
             } else {
-                Map<String, Object> map = new HashMap<>();
-                for (Map.Entry<String, Object> entry : jsObjectMirror.entrySet()) {
-                    map.put(entry.getKey(), jsonToJava(entry.getValue()));
-                }
-                return map;
+                return jsObj;
             }
-        } else {
-            return jsObj;
-        }
+        } catch (Exception ignored) {return jsObj;}
     }
 
     protected static Object ymlToJavaObj(Object obj) {

--- a/src/main/java/com/extendedclip/papi/expansion/javascript/ExpansionUtils.java
+++ b/src/main/java/com/extendedclip/papi/expansion/javascript/ExpansionUtils.java
@@ -87,7 +87,7 @@ public class ExpansionUtils {
             } else {
                 return jsObj;
             }
-        } catch (Exception ignored) {return jsObj;}
+        } catch (NoClassDefFoundError ignored) {return jsObj;}
     }
 
     protected static Object ymlToJavaObj(Object obj) {

--- a/src/main/java/com/extendedclip/papi/expansion/javascript/JavascriptExpansion.java
+++ b/src/main/java/com/extendedclip/papi/expansion/javascript/JavascriptExpansion.java
@@ -28,6 +28,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandMap;
+import org.bukkit.plugin.RegisteredServiceProvider;
 import org.jetbrains.annotations.NotNull;
 
 import javax.script.ScriptEngine;
@@ -83,13 +84,16 @@ public class JavascriptExpansion extends PlaceholderExpansion implements Cacheab
     @Override
     public boolean register() {
         String defaultEngine = ExpansionUtils.DEFAULT_ENGINE;
+        RegisteredServiceProvider<ScriptEngineManager> servicesManager = Bukkit.getServer().getServicesManager().getRegistration(ScriptEngineManager.class);
+        ScriptEngineManager scriptEngineManager = servicesManager.getProvider();
+
 
         if (globalEngine == null) {
             try {
-                globalEngine = new ScriptEngineManager(null).getEngineByName(getString("engine", defaultEngine));
+                globalEngine = scriptEngineManager.getEngineByName(getString("engine", defaultEngine));
             } catch (NullPointerException ex) {
                 ExpansionUtils.warnLog("Javascript engine type was invalid! Defaulting to '" + defaultEngine + "'", null);
-                globalEngine = new ScriptEngineManager(null).getEngineByName(defaultEngine);
+                globalEngine = scriptEngineManager.getEngineByName(defaultEngine);
             }
         }
 
@@ -109,7 +113,7 @@ public class JavascriptExpansion extends PlaceholderExpansion implements Cacheab
         if (debug) {
             ExpansionUtils.infoLog("Java version: " + System.getProperty("java.version"));
     
-            final ScriptEngineManager manager = new ScriptEngineManager(null);
+            final ScriptEngineManager manager = scriptEngineManager;
             final List<ScriptEngineFactory> factories = manager.getEngineFactories();
             ExpansionUtils.infoLog("Displaying all script engine factories.", false);
 

--- a/src/main/java/com/extendedclip/papi/expansion/javascript/cloud/GithubScriptManager.java
+++ b/src/main/java/com/extendedclip/papi/expansion/javascript/cloud/GithubScriptManager.java
@@ -25,7 +25,6 @@ import com.extendedclip.papi.expansion.javascript.JavascriptExpansion;
 import com.extendedclip.papi.expansion.javascript.JavascriptPlaceholdersConfig;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
-import jdk.nashorn.api.scripting.ScriptUtils;
 import org.bukkit.Bukkit;
 
 import java.io.*;
@@ -33,7 +32,6 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.logging.Level;
 import java.util.stream.Collectors;
 
 public class GithubScriptManager {


### PR DESCRIPTION
Hey 🖐
I was looking through the code to try to understand why in the world wouldn't the expansion detect Graal.js nor the JSEngine plugin and I've noticed that the expansion just created a new instance of the ScriptEngineManager while it could (should?) use the Bukkit ServicesManager.
I've realized that it might have been the cause JSEngine states it on its Spigot page
![image](https://user-images.githubusercontent.com/45695833/120068720-70761380-c082-11eb-948f-33c4b7a1a6e9.png)

So I tried to use that, and it turns out it detected Graal.js correctly!
![image](https://user-images.githubusercontent.com/45695833/120068744-90a5d280-c082-11eb-95f2-03cdd2587329.png)
Idk with JSEngine since I was lazy to try x) but I guess it should work as well.
Anyways, hopefully this helps =)