### PR TITLE
fix: nashorn-core shading as standalone javascript engine for java 15

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,3 @@
 Adds javascript placeholders
 [![Build Status](http://ci.extendedclip.com/buildStatus/icon?job=Javascript-Expansion)](http://ci.extendedclip.com/job/Javascript-Expansion/)
 [![Discord](https://discord.com/api/guilds/164280494874165248/widget.png)](http://helpch.at/discord)
-
-**NOTE**: Nashorn engine will not work with JVM 15 and above!

--- a/pom.xml
+++ b/pom.xml
@@ -22,13 +22,17 @@
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
             <version>1.16.5-R0.1-SNAPSHOT</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
          <groupId>me.clip</groupId>
           <artifactId>placeholderapi</artifactId>
           <version>2.10.9</version>
          <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.nashorn</groupId>
+            <artifactId>nashorn-core</artifactId>
+            <version>15.0</version>
         </dependency>
     </dependencies>
     
@@ -53,11 +57,31 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <target>1.8</target>
-                    <source>1.8</source>
+                    <target>15</target>
+                    <source>15</source>
                     <encoding>UTF-8</encoding>
                     <useIncrementalCompilation>false</useIncrementalCompilation>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.4</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>org.openjdk.nashorn:nashorn-core</include>
+                                </includes>
+                            </artifactSet>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/com/extendedclip/papi/expansion/javascript/ExpansionUtils.java
+++ b/src/main/java/com/extendedclip/papi/expansion/javascript/ExpansionUtils.java
@@ -1,11 +1,11 @@
 package com.extendedclip.papi.expansion.javascript;
 
-import jdk.nashorn.api.scripting.ScriptObjectMirror;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.MemorySection;
 import org.jetbrains.annotations.NotNull;
+import org.openjdk.nashorn.api.scripting.ScriptObjectMirror;
 
 import java.util.*;
 import java.util.logging.Level;

--- a/src/main/java/com/extendedclip/papi/expansion/javascript/JavascriptPlaceholdersConfig.java
+++ b/src/main/java/com/extendedclip/papi/expansion/javascript/JavascriptPlaceholdersConfig.java
@@ -35,12 +35,14 @@ public class JavascriptPlaceholdersConfig {
 
     private final JavascriptExpansion ex;
     private final PlaceholderAPIPlugin plugin;
+    public ScriptEngineManager engineManager;
     private FileConfiguration config;
     private File file;
 
     public JavascriptPlaceholdersConfig(JavascriptExpansion ex) {
         this.ex = ex;
         plugin = ex.getPlaceholderAPI();
+        engineManager = ex.engineManager;
         reload();
     }
 
@@ -161,7 +163,7 @@ public class JavascriptPlaceholdersConfig {
                 }
             } else {
                 try {
-                   engine = new ScriptEngineManager(null).getEngineByName(config.getString(identifier + ".engine", "nashorn"));
+                   engine = engineManager.getEngineByName(config.getString(identifier + ".engine", "nashorn"));
                 } catch (NullPointerException e) {
                     if (debug) {
                         ExpansionUtils.warnLog("ScriptEngine type for javascript placeholder: " + identifier + " is invalid! Defaulting to global", null);

--- a/src/main/java/com/extendedclip/papi/expansion/javascript/cloud/GithubScriptManager.java
+++ b/src/main/java/com/extendedclip/papi/expansion/javascript/cloud/GithubScriptManager.java
@@ -25,7 +25,6 @@ import com.extendedclip.papi.expansion.javascript.JavascriptExpansion;
 import com.extendedclip.papi.expansion.javascript.JavascriptPlaceholdersConfig;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
-import jdk.nashorn.api.scripting.ScriptUtils;
 import org.bukkit.Bukkit;
 
 import java.io.*;


### PR DESCRIPTION
Added Java 15+ compatibility using nashorn-core as a shaded dependency. Engine manager adds "nashorn".
Current PR compiled with Java 15 for nashorn-core compatibility.