### PR TITLE
fix for #73

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,8 @@ allprojects {
     group = 'com.extendedclip.papi.expansion.javascript'
     version = '2.1.2'
     description = 'PAPI-Expansion-Javascript'
+
+    apply(plugin: 'java')
 }
 
 repositories {

--- a/evaluator/src/main/java/com/extendedclip/papi/expansion/javascript/evaluator/NashornScriptEvaluator.java
+++ b/evaluator/src/main/java/com/extendedclip/papi/expansion/javascript/evaluator/NashornScriptEvaluator.java
@@ -1,7 +1,5 @@
 package com.extendedclip.papi.expansion.javascript.evaluator;
 
-import org.openjdk.nashorn.api.scripting.NashornScriptEngineFactory;
-
 import javax.script.Bindings;
 import javax.script.ScriptContext;
 import javax.script.ScriptEngine;
@@ -9,21 +7,22 @@ import javax.script.ScriptException;
 import java.util.Map;
 
 public final class NashornScriptEvaluator implements ScriptEvaluator {
-    private final NashornScriptEngineFactory scriptEngineFactory;
+
+    private final ScriptEngine scriptEngine;
     private final Map<String, Object> bindings;
 
-    public NashornScriptEvaluator(final NashornScriptEngineFactory scriptEngineFactory, final Map<String, Object> bindings) {
-        this.scriptEngineFactory = scriptEngineFactory;
+    public NashornScriptEvaluator(final ScriptEngine scriptEngine, final Map<String, Object> bindings) {
+        this.scriptEngine = scriptEngine;
         this.bindings = bindings;
     }
 
     @Override
     public Object execute(final Map<String, Object> additionalBindings, final String script) throws EvaluatorException, ScriptException {
-        final ScriptEngine engine = scriptEngineFactory.getScriptEngine("--no-java");
-        final Bindings globalBindings = engine.getBindings(ScriptContext.ENGINE_SCOPE);
+        final Bindings globalBindings = scriptEngine.getBindings(ScriptContext.ENGINE_SCOPE);
         globalBindings.putAll(bindings);
         globalBindings.putAll(additionalBindings);
-        engine.setBindings(globalBindings, ScriptContext.GLOBAL_SCOPE);
-        return engine.eval(script);
+        scriptEngine.setBindings(globalBindings, ScriptContext.ENGINE_SCOPE);
+        return scriptEngine.eval(script);
     }
+
 }

--- a/evaluator/src/main/java/com/extendedclip/papi/expansion/javascript/evaluator/NashornScriptEvaluatorFactory.java
+++ b/evaluator/src/main/java/com/extendedclip/papi/expansion/javascript/evaluator/NashornScriptEvaluatorFactory.java
@@ -3,6 +3,7 @@ package com.extendedclip.papi.expansion.javascript.evaluator;
 import com.extendedclip.papi.expansion.javascript.evaluator.util.InjectionUtil;
 import org.openjdk.nashorn.api.scripting.NashornScriptEngineFactory;
 
+import javax.script.ScriptEngine;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.security.NoSuchAlgorithmException;
@@ -17,16 +18,16 @@ public final class NashornScriptEvaluatorFactory implements ScriptEvaluatorFacto
             "asm-util-9.2.isolated-jar",
             "asm-9.2.isolated-jar"
     );
-    private final NashornScriptEngineFactory engineFactory;
+
+    private final ThreadLocal<ScriptEngine> engines;
 
     private NashornScriptEvaluatorFactory(final NashornScriptEngineFactory engineFactory) {
-        this.engineFactory = engineFactory;
+        this.engines = ThreadLocal.withInitial(() -> engineFactory.getScriptEngine("--no-java"));
     }
-
 
     @Override
     public ScriptEvaluator create(final Map<String, Object> bindings) {
-        return new NashornScriptEvaluator(engineFactory, bindings);
+        return new NashornScriptEvaluator(engines.get(), bindings);
     }
 
     public static ScriptEvaluatorFactory create() throws URISyntaxException, ReflectiveOperationException, NoSuchAlgorithmException, IOException {


### PR DESCRIPTION
According to some SO posts, we can (and should) use a single instance of ScriptEngine. What needs to be created every time are the Bindings, which we already do.